### PR TITLE
feat: add non-triggerable sObjects reference to automation-flow-generate and platform-apex-generate skills

### DIFF
--- a/skills/automation-flow-generate/SKILL.md
+++ b/skills/automation-flow-generate/SKILL.md
@@ -201,6 +201,12 @@ When no custom objects needed:
 
 The pipeline selects flow elements from your `userPrompt`. Vague prompts lead the pipeline to pick wrong structures, producing metadata that fails deployment. When the request matches one of the patterns below, make the intent explicit in the `userPrompt` you pass to Step 1 and Step 2 so the pipeline selects the correct elements.
 
+### Record-Triggered flows — verify triggerability first
+
+Not all SObjects support Record-Triggered Flows — before running the pipeline, check the target object against `references/non-triggerable-sobjects.md`.
+If the object is on that list, stop and explain — do not run the generation pipeline for that object.
+The list is a heuristic covering obvious cases (setup/audit/history/log objects) and isn't exhaustive; if the object isn't on it, proceed with generation.
+
 ### Scheduled flows ("daily", "weekly", "every Sunday", "runs once a week at 10PM")
 
 A recurring, time-based flow is a **Scheduled** flow. The schedule lives on the **start element**: `triggerType` is `Scheduled` and a `<schedule>` block holds `<frequency>` (e.g. `Weekly`), `<startDate>`, and `<startTime>`. Do NOT expect `startDate`/`startTime` on a `FlowScheduledPath` element — a scheduled flow's cadence is on `<start><schedule>`, not a scheduled path.

--- a/skills/automation-flow-generate/references/non-triggerable-sobjects.md
+++ b/skills/automation-flow-generate/references/non-triggerable-sobjects.md
@@ -1,0 +1,25 @@
+# Known Non-Triggerable Standard Objects
+
+Fast-path heuristic used by the Record-Triggered flows section of `SKILL.md` to decide
+whether to stop before running the generation pipeline. It is not exhaustive: custom
+objects, managed-package objects, and new/changed standard objects per release may not
+be listed here.
+
+Common standard objects where Record-Triggered Flows (and Apex triggers) are **not** supported:
+
+- `LoginHistory`
+- `SetupAuditTrail`
+- `LoginGeo`
+- `LoginIp`
+- `AsyncApexJob`
+- `ApexLog`
+- `EventLogFile`
+- `FieldHistoryArchive` / `__hd` big objects
+- `AggregateResult`
+- `UserRole` (limited/no trigger support historically — verify per org)
+- `PermissionSetAssignment`-adjacent setup/audit objects generally
+- all *Share objects
+- all *History objects
+- Most objects under Setup that are system-managed and read-only (audit, history, log objects)
+
+If the target object isn't in one of these categories, proceed with the generation pipeline.

--- a/skills/platform-apex-generate/SKILL.md
+++ b/skills/platform-apex-generate/SKILL.md
@@ -328,6 +328,9 @@ Method-level format:
 - Template: `assets/trigger.cls`
 - One trigger per object; delegate all logic to handler/TAF action classes
 - Include all relevant DML contexts; if TAF: `new MetadataTriggerHandler().run();`
+- Not all SObjects allow triggers — before authoring, check the target object against `references/non-triggerable-sobjects.md`.
+  If the object is on that list, stop and explain — do not generate the trigger.
+  The list is a heuristic covering obvious cases (setup/audit/history/log objects) and isn't exhaustive; if the object isn't on it, proceed with authoring.
 
 ### Trigger Action (TAF)
 - One class per concern per context; implement `TriggerAction.{Context}`

--- a/skills/platform-apex-generate/references/non-triggerable-sobjects.md
+++ b/skills/platform-apex-generate/references/non-triggerable-sobjects.md
@@ -1,0 +1,24 @@
+# Known Non-Triggerable Standard Objects
+
+Fast-path heuristic used by the Trigger section of `SKILL.md` to decide whether to stop
+before authoring. It is not exhaustive: custom objects, managed-package objects, and
+new/changed standard objects per release may not be listed here.
+
+Common standard objects where Apex triggers are **not** supported:
+
+- `LoginHistory`
+- `SetupAuditTrail`
+- `LoginGeo`
+- `LoginIp`
+- `AsyncApexJob`
+- `ApexLog`
+- `EventLogFile`
+- `FieldHistoryArchive` / `__hd` big objects
+- `AggregateResult`
+- `UserRole` (limited/no trigger support historically — verify per org)
+- `PermissionSetAssignment`-adjacent setup/audit objects generally
+- all *Share objects
+- all *History objects
+- Most objects under Setup that are system-managed and read-only (audit, history, log objects)
+
+If the target object isn't in one of these categories, proceed with authoring the trigger.


### PR DESCRIPTION
### Summary
Adds a guardrail to the automation-flow-generate and platform-apex-generate skills so they check whether a target SObject supports Record-Triggered Flows / Apex triggers before running the generation pipeline, stopping early on known-unsupported objects instead of generating metadata that will fail to deploy.

### Changes
- SKILL.md: added a "Record-Triggered flows — verify triggerability first" section instructing the pipeline to check the target object against references/non-triggerable-sobjects.md before generating, and to stop and explain if the object is unsupported.
- non-triggerable-sobjects.md (new): reference list of common standard objects that don't support Record-Triggered Flows (e.g. -LoginHistory, SetupAuditTrail, AsyncApexJob, ApexLog, *Share/*History objects, etc.).
- SKILL.md: added the same triggerability check to the Trigger authoring section, referencing its own references/non-triggerable-sobjects.md.
- non-triggerable-sobjects.md (new): equivalent reference list for Apex trigger generation.

### Motivation
AI generation frequently attempts to create Apex triggers or Record-Triggered Flows on objects that don't support them (setup, audit, history, and log objects), producing metadata that fails deployment. This heuristic gives both skills an early, explicit check to catch obvious cases and avoid wasted generation attempts.

### Notes
The reference lists are intentionally heuristic, not exhaustive — custom objects, managed-package objects, and new/changed standard objects per release may not be covered. Both docs state this explicitly.
No functional/pipeline code changed — this is skill documentation/reference guidance only.
Reviewers may want to sanity-check the object list for accuracy (e.g. UserRole is noted as "verify per org").