### PR TITLE
fix(salesforce-development): verify-org gate honors --target-org / -o

### DIFF
--- a/plugins/builder/salesforce-development/scripts/sf_context.py
+++ b/plugins/builder/salesforce-development/scripts/sf_context.py
@@ -3775,9 +3775,21 @@ def cmd_verify_org() -> int:
     # whenever no org is set, blocking ordinary shell use. Anything that is not a
     # deploy/delete is always allowed, before any CLI work.
     payload = _read_hook_payload()
-    if not _DEPLOY_OR_DELETE_COMMAND.search(_hook_command(payload)):
+    command = _hook_command(payload)
+    if not _DEPLOY_OR_DELETE_COMMAND.search(command):
         print(json.dumps({"continue": True}))
         return 0
+
+    # The org to verify is the one the deploy will actually hit. An explicit
+    # `--target-org` / `-o` on the deploy segment names it outright (the sibling
+    # bash gate, sf-deploy-gate, reads the same flag); only a segment WITHOUT the
+    # flag falls back to the default org, and only then is a default required.
+    # Before this, the gate ignored the flag and demanded a default org from the
+    # hook's cwd — which denied every `sf … deploy -o <alias>` run from a
+    # non-project directory even though the CLI itself had a perfectly good target.
+    explicit = _explicit_deploy_target_orgs(command)
+    targets = list(dict.fromkeys(o for o in explicit if o))
+    needs_default = any(not o for o in explicit)
 
     # W-23466800 (WIN-027): distinguish "the CLI itself can't be resolved" from "no org set".
     # An unresolvable `sf` is an environment failure, not a config choice;
@@ -3804,7 +3816,7 @@ def cmd_verify_org() -> int:
         )
         return 0
 
-    target, err = get_target_org_detailed()
+    target, err = get_target_org_detailed() if needs_default else ("", "")
     if err:
         # CLI present but the query failed — fail closed, but say WHY (not a false
         # "no org"), with a secret-free diagnostic (W-23466800 / WIN-027).
@@ -3820,23 +3832,26 @@ def cmd_verify_org() -> int:
             ),
         )
         return 0
-    if not target:
+    if needs_default and not target:
         emit(
             "PreToolUse",
             "",
             decision="deny",
-            reason=tag + "No target org is configured. Run 'sf config set target-org <alias>' before deploying.",
+            reason=tag + "No target org is configured. Run 'sf config set target-org <alias>' before deploying, or pass --target-org <alias> on the command.",
         )
         return 0
+    if needs_default and target not in targets:
+        targets.append(target)
 
-    if not get_org_display(target):
-        emit(
-            "PreToolUse",
-            "",
-            decision="deny",
-            reason=tag + "Cannot reach the target org. Your session may have expired. Run 'sf org login web' to re-authenticate.",
-        )
-        return 0
+    for org in targets:
+        if not get_org_display(org):
+            emit(
+                "PreToolUse",
+                "",
+                decision="deny",
+                reason=tag + f"Cannot reach the target org '{_sanitize_dynamic_text(org)}'. Your session may have expired. Run 'sf org login web' to re-authenticate.",
+            )
+            return 0
 
     print(json.dumps({"continue": True}))
     return 0
@@ -4033,6 +4048,31 @@ def _hook_command(payload: dict) -> str:
     """The executed Bash command from a PreToolUse/PostToolUse hook payload, or ""."""
     tool_input = payload.get("tool_input") or payload.get("toolInput") or {}
     return (tool_input.get("command") or "") if isinstance(tool_input, dict) else ""
+
+
+# Shell segment boundaries: `;`, `&&`, `||`, `|` and newlines. A flag is judged on
+# the segment that carries it — `-o` on an `sf org display` segment says nothing
+# about the `sf project deploy` that follows it.
+_SHELL_SEGMENT_SPLIT = re.compile(r"\s*(?:\|\||&&|;|\||\n)\s*")
+# `--target-org X`, `--target-org=X`, `-o X`, `-o=X`; X may be single- or
+# double-quoted. The flag must start a word so `foo-o` never reads as `-o`.
+_TARGET_ORG_FLAG = re.compile(
+    r"""(?:^|\s)(?:--target-org|-o)(?:=|\s+)(?:"([^"]*)"|'([^']*)'|(\S+))"""
+)
+
+
+def _explicit_deploy_target_orgs(command: str) -> list:
+    """One entry per `sf project deploy|delete` shell segment, in command order:
+    the org that segment names with its own `--target-org` / `-o` flag, or "" when
+    it has none (the CLI then falls back to the default org). Non-deploy segments
+    are skipped, so their `-o` never counts. [] when nothing deploys or deletes."""
+    orgs = []
+    for segment in _SHELL_SEGMENT_SPLIT.split(command or ""):
+        if not _DEPLOY_OR_DELETE_COMMAND.search(segment):
+            continue
+        m = _TARGET_ORG_FLAG.search(segment)
+        orgs.append(next((g for g in m.groups() if g is not None), "") if m else "")
+    return orgs
 
 
 def _hook_reports_failure(payload: object) -> bool:

--- a/plugins/builder/salesforce-development/scripts/test/test_discovery_runtime.py
+++ b/plugins/builder/salesforce-development/scripts/test/test_discovery_runtime.py
@@ -3166,6 +3166,71 @@ class DeployHookSelfGateTests(unittest.TestCase):
                     _, result = self.run_hook(sfx.cmd_verify_org, cmd)
                 self.assertEqual(result, {"continue": True})
 
+    def test_verify_org_honors_an_explicit_target_org_flag(self):
+        # An explicit --target-org / -o on the deploy segment IS the target: the
+        # gate must verify THAT org and never consult (or require) the default org.
+        # The sibling bash gate (sf-deploy-gate) already reads the flag; this keeps
+        # the two gates consistent for the home-directory / multi-org workflow.
+        for cmd in (
+            "sf project deploy start -o acme --source-dir force-app",
+            "sf project deploy start --target-org acme --source-dir force-app",
+            "sf project deploy start --target-org=acme --source-dir force-app",
+            "cd /tmp/proj && sf project deploy start --source-dir force-app -o acme --json | jq .",
+            "sf project delete source --metadata Flow:X --target-org acme --no-prompt",
+        ):
+            with self.subTest(cmd=cmd):
+                with mock.patch.object(sfx, "resolve_executable", return_value="/usr/bin/sf"), \
+                        mock.patch.object(sfx, "get_target_org_detailed", return_value=("", "")) as gto, \
+                        mock.patch.object(sfx, "get_org_display", return_value={"alias": "acme"}) as god:
+                    _, result = self.run_hook(sfx.cmd_verify_org, cmd)
+                self.assertEqual(result, {"continue": True})
+                gto.assert_not_called()
+                god.assert_called_once_with("acme")
+
+    def test_verify_org_explicit_flag_still_fails_closed_when_unreachable(self):
+        with mock.patch.object(sfx, "resolve_executable", return_value="/usr/bin/sf"), \
+                mock.patch.object(sfx, "get_target_org_detailed", return_value=("other", "")), \
+                mock.patch.object(sfx, "get_org_display", return_value={}):
+            _, result = self.run_hook(sfx.cmd_verify_org, "sf project deploy start -o gone --source-dir x")
+        self.assertEqual(result.get("hookSpecificOutput", {}).get("permissionDecision"), "deny")
+
+    def test_verify_org_flag_on_another_segment_does_not_count(self):
+        # `-o` belongs to `sf org display`, not to the deploy — the deploy will run
+        # against the DEFAULT org, so the gate must still require one.
+        cmd = "sf org display -o acme --json && sf project deploy start --source-dir force-app"
+        with mock.patch.object(sfx, "resolve_executable", return_value="/usr/bin/sf"), \
+                mock.patch.object(sfx, "get_target_org_detailed", return_value=("", "")) as gto:
+            _, result = self.run_hook(sfx.cmd_verify_org, cmd)
+        self.assertEqual(result.get("hookSpecificOutput", {}).get("permissionDecision"), "deny")
+        gto.assert_called_once()
+
+    def test_verify_org_mixed_segments_require_the_default_org(self):
+        # Two deploys, one explicit and one not: the bare one uses the default org,
+        # so the default must exist; the explicit one is verified on its own alias.
+        cmd = "sf project deploy start -o acme --source-dir a; sf project deploy start --source-dir b"
+        with mock.patch.object(sfx, "resolve_executable", return_value="/usr/bin/sf"), \
+                mock.patch.object(sfx, "get_target_org_detailed", return_value=("dflt", "")), \
+                mock.patch.object(sfx, "get_org_display", return_value={"alias": "x"}) as god:
+            _, result = self.run_hook(sfx.cmd_verify_org, cmd)
+        self.assertEqual(result, {"continue": True})
+        self.assertEqual(sorted(c.args[0] for c in god.call_args_list), ["acme", "dflt"])
+
+    def test_explicit_target_orgs_parser(self):
+        f = sfx._explicit_deploy_target_orgs
+        self.assertEqual(f("sf project deploy start -o acme --json"), ["acme"])
+        self.assertEqual(f("sf project deploy start --target-org=acme"), ["acme"])
+        self.assertEqual(f("sf project deploy start --target-org 'my org'"), ["my org"])
+        self.assertEqual(f('sf project deploy start --target-org "my org"'), ["my org"])
+        # `-o` inside another flag's value or a word is not the flag.
+        self.assertEqual(f("sf project deploy start --source-dir foo-o"), [""])
+        self.assertEqual(f("sf project deploy start --wait 30"), [""])
+        # One entry per deploy/delete segment, in order; `-o` on other segments ignored.
+        self.assertEqual(
+            f("sf org display -o zz && sf project deploy start -o a; sf project delete source"),
+            ["a", ""],
+        )
+        self.assertEqual(f("ls"), [])
+
     def test_post_deploy_silent_on_non_deploy_advises_on_deploy(self):
         _, silent = self.run_hook(sfx.cmd_post_deploy, "cd /tmp && grep foo .")
         self.assertEqual(silent, {"continue": True})


### PR DESCRIPTION
## What changed

`salesforce-development` plugin — the `verify-org` PreToolUse gate (fires on `sf project deploy|delete`, fails closed) now honors the command's own `--target-org` / `-o` flag.

- New `_explicit_deploy_target_orgs()` in `scripts/sf_context.py`: one entry per `sf project deploy|delete` shell segment (split on `;` `&&` `||` `|` and newlines) — that segment's `--target-org X` / `--target-org=X` / `-o X` / `-o=X` (quoted or bare), or `""` when it has none. A flag on a neighbouring segment (e.g. `sf org display -o …`) never counts, and the flag must start a word so `foo-o` is not read as `-o`.
- `cmd_verify_org`: each explicit alias is verified with `sf org display` directly; the default org is consulted — and required — only for a deploy segment that carries no flag. An unreachable explicit alias still denies (fail-closed) and now names the alias. The "no org" denial adds "or pass `--target-org <alias>` on the command".
- The non-deploy short-circuit and the CLI-missing / CLI-failed branches are unchanged.

## Why

The gate never read the flag. It resolved the org with `sf config get target-org` from the hook's cwd and denied with "No target org is configured" whenever that returned nothing. So `sf project deploy start -o <alias> --source-dir …` was refused from any directory without a default org — even though the CLI had a perfectly good target — while the same command with `--dry-run` passed, because dry-runs are exempt. Anyone who opens Claude Code outside a DX project (or works across several orgs and deliberately keeps no default) hits this on every real deploy.

The sibling bash gate (`scripts/sf-deploy-gate`, `extract_target_org_from_command`) already parses the flag, so the two gates disagreed about which org a command targets. This brings the Python gate in line, and judges the flag per shell segment so a `-o` elsewhere on the line can't be mistaken for the deploy's target.

## Notes

Tests were written failing first — 5 new cases in `DeployHookSelfGateTests` (`scripts/test/test_discovery_runtime.py`): explicit flag forms incl. `--target-org=` and a mid-pipeline deploy, unreachable explicit alias, flag on another segment, mixed explicit/bare segments, and parser edge cases.

```
cd plugins/builder/salesforce-development/scripts/test
python3 -m unittest test_discovery_runtime.DeployHookSelfGateTests   # 14 tests, OK
```

Full offline suite (`python3 -m unittest discover -s . -p 'test_*.py'` + every `*.test.sh`) on this branch vs. pristine `main`: 1163 → 1168 tests, with the identical set of pre-existing failures on both sides (release-tree / catalog-provenance tests that need the full repo and internal config; unrelated to this change). `gate-decision` 31/31, `skills-first-advisory` 54/54, `post-deploy-failure` 7/7.

Also exercised end to end through the real `sf-context verify-org` entrypoint from a non-project cwd with no default org: explicit reachable alias → allow; bare deploy → deny; `-o` on a neighbouring `sf org display` segment → deny; explicit unreachable alias → deny (naming it); `ls` → allow.

Not a skill change, so the Skills checklist below doesn't apply.
